### PR TITLE
Add classifieds platform boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# nameless-lab
+# Classifieds PWA
+
+## Setup
+
+```bash
+pnpm install
+pnpm dev
+```
+
+## Environment Variables
+
+- `DATABASE_URL`
+- `NEXTAUTH_SECRET`
+- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`
+- `APPLE_CLIENT_ID`, `APPLE_CLIENT_SECRET`
+- `IG_CLIENT_ID`, `IG_CLIENT_SECRET`
+- `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`
+- `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,119 @@
+// Prisma schema for classifieds platform
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum CategoryType {
+  JOB
+  HOUSING
+  MARKET
+  QA
+}
+
+enum ListingStatus {
+  ACTIVE
+  EXPIRED
+}
+
+enum TrustEventType {
+  TRANSACTION
+  RATING
+  PENALTY
+}
+
+enum PaymentStatus {
+  PENDING
+  SUCCESS
+  FAILED
+}
+
+model User {
+  id          String       @id @default(uuid())
+  email       String       @unique
+  name        String?
+  image       String?
+  provider    String
+  providerId  String
+  verifiedAt  DateTime?
+  listings    Listing[]
+  trustEvents TrustEvent[]
+  payments    Payment[]
+  tickets     SupportTicket[]
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+}
+
+model Category {
+  id         String       @id @default(uuid())
+  type       CategoryType
+  label      String
+  listings   Listing[]
+  createdAt  DateTime     @default(now())
+}
+
+model Listing {
+  id            String           @id @default(uuid())
+  user          User             @relation(fields: [userId], references: [id])
+  userId        String
+  category      Category         @relation(fields: [categoryId], references: [id])
+  categoryId    String
+  title         String
+  description   String
+  price         Float?
+  status        ListingStatus    @default(ACTIVE) @index
+  promoted      Boolean          @default(false)
+  expiresAt     DateTime         @index
+  versions      ListingVersion[]
+  payments      Payment[]
+  createdAt     DateTime         @default(now())
+  updatedAt     DateTime         @updatedAt
+}
+
+model ListingVersion {
+  id          String   @id @default(uuid())
+  listing     Listing  @relation(fields: [listingId], references: [id])
+  listingId   String   @index
+  version     Int
+  title       String
+  description String
+  price       Float?
+  createdAt   DateTime @default(now())
+}
+
+model TrustEvent {
+  id        String         @id @default(uuid())
+  user      User           @relation(fields: [userId], references: [id])
+  userId    String         @index
+  type      TrustEventType
+  value     Float
+  createdAt DateTime       @default(now())
+}
+
+model Payment {
+  id            String        @id @default(uuid())
+  user          User          @relation(fields: [userId], references: [id])
+  userId        String        @index
+  listing       Listing       @relation(fields: [listingId], references: [id])
+  listingId     String        @index
+  stripeId      String
+  amount        Float
+  currency      String
+  status        PaymentStatus @default(PENDING)
+  createdAt     DateTime      @default(now())
+}
+
+model SupportTicket {
+  id        String   @id @default(uuid())
+  user      User?    @relation(fields: [userId], references: [id])
+  userId    String?
+  message   String
+  createdAt DateTime @default(now())
+}
+
+@@index([title, description], type: FullText, map: "listing_search_idx")

--- a/src/jobs/expireListings.ts
+++ b/src/jobs/expireListings.ts
@@ -1,0 +1,14 @@
+import cron from "node-cron";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export function startExpiryJob() {
+  cron.schedule("0 * * * *", async () => {
+    const now = new Date();
+    await prisma.listing.updateMany({
+      where: { expiresAt: { lt: now }, status: "ACTIVE" },
+      data: { status: "EXPIRED" },
+    });
+  });
+}

--- a/src/lib/idVerification.ts
+++ b/src/lib/idVerification.ts
@@ -1,0 +1,28 @@
+import { RekognitionClient, DetectTextCommand } from "@aws-sdk/client-rekognition";
+import { PrismaClient } from "@prisma/client";
+
+const rekognition = new RekognitionClient({ region: process.env.AWS_REGION });
+const prisma = new PrismaClient();
+
+export async function verifyIdImage(userId: string, base64Image: string) {
+  try {
+    const imageBuffer = Buffer.from(base64Image, "base64");
+    const detectCommand = new DetectTextCommand({
+      Image: { Bytes: imageBuffer },
+    });
+    const result = await rekognition.send(detectCommand);
+    const text = result.TextDetections?.map(t => t.DetectedText).join(" ") || "";
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new Error("User not found");
+    if (user.name && text.includes(user.name)) {
+      await prisma.user.update({
+        where: { id: userId },
+        data: { verifiedAt: new Date() },
+      });
+      return { success: true } as const;
+    }
+    return { success: false, error: "Name mismatch" } as const;
+  } catch (error) {
+    return { success: false, error: (error as Error).message } as const;
+  }
+}

--- a/src/lib/trust.ts
+++ b/src/lib/trust.ts
@@ -1,0 +1,17 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export async function getTrustScore(userId: string) {
+  const events = await prisma.trustEvent.findMany({ where: { userId } });
+  const completed = events.filter(e => e.type === "TRANSACTION").length;
+  const ratingSum = events
+    .filter(e => e.type === "RATING")
+    .reduce((sum, e) => sum + e.value, 0);
+  const ratingCount = events.filter(e => e.type === "RATING").length;
+  const penalty = events
+    .filter(e => e.type === "PENALTY")
+    .reduce((sum, e) => sum + e.value, 0);
+  const ratingAvg = ratingCount ? ratingSum / ratingCount : 0;
+  return completed + ratingAvg - penalty;
+}

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,67 @@
+import NextAuth from "next-auth";
+import GoogleProvider from "next-auth/providers/google";
+import AppleProvider from "next-auth/providers/apple";
+import InstagramProvider from "next-auth/providers/instagram";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export default NextAuth({
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    }),
+    AppleProvider({
+      clientId: process.env.APPLE_CLIENT_ID!,
+      clientSecret: process.env.APPLE_CLIENT_SECRET!,
+    }),
+    InstagramProvider({
+      clientId: process.env.IG_CLIENT_ID!,
+      clientSecret: process.env.IG_CLIENT_SECRET!,
+    }),
+  ],
+  callbacks: {
+    async signIn({ user, account }) {
+      if (!user.email) return false;
+      await prisma.user.upsert({
+        where: { email: user.email },
+        update: {
+          name: user.name ?? undefined,
+          image: user.image ?? undefined,
+          provider: account?.provider || "oauth",
+          providerId: account?.providerAccountId || "",
+        },
+        create: {
+          email: user.email,
+          name: user.name ?? undefined,
+          image: user.image ?? undefined,
+          provider: account?.provider || "oauth",
+          providerId: account?.providerAccountId || "",
+        },
+      });
+      return true;
+    },
+    async session({ session, token }) {
+      if (session.user?.email) {
+        const dbUser = await prisma.user.findUnique({
+          where: { email: session.user.email },
+        });
+        if (dbUser) {
+          session.user.id = dbUser.id;
+          session.user.verifiedAt = dbUser.verifiedAt;
+        }
+      }
+      return session;
+    },
+  },
+  events: {
+    async signIn({ user }) {
+      if (!user.email) return;
+      const dbUser = await prisma.user.findUnique({ where: { email: user.email } });
+      if (dbUser && !dbUser.verifiedAt) {
+        // TODO: redirect to verification flow on frontend
+      }
+    },
+  },
+});

--- a/src/pages/api/feed.ts
+++ b/src/pages/api/feed.ts
@@ -1,0 +1,20 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { PrismaClient } from "@prisma/client";
+import { getTrustScore } from "../lib/trust";
+
+const prisma = new PrismaClient();
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const listings = await prisma.listing.findMany({
+    where: { status: "ACTIVE" },
+    orderBy: { createdAt: "desc" },
+    include: { user: true },
+  });
+  const data = await Promise.all(
+    listings.map(async l => ({
+      ...l,
+      trustScore: await getTrustScore(l.userId),
+    }))
+  );
+  res.json({ success: true, data });
+}

--- a/src/pages/api/listings/[id]/edit.ts
+++ b/src/pages/api/listings/[id]/edit.ts
@@ -1,0 +1,42 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../../auth/[...nextauth]";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "PUT") return res.status(405).end();
+  const session = await getServerSession(req, res, authOptions as any);
+  if (!session?.user?.id) return res.status(401).json({ success: false, error: "Unauthorized" });
+  const listingId = req.query.id as string;
+  const { title, description, price } = req.body;
+  try {
+    const listing = await prisma.listing.findUnique({ where: { id: listingId } });
+    if (!listing || listing.userId !== session.user.id) {
+      return res.status(403).json({ success: false, error: "Forbidden" });
+    }
+    const versionCount = await prisma.listingVersion.count({ where: { listingId } });
+    const newVersion = await prisma.listingVersion.create({
+      data: {
+        listingId,
+        version: versionCount + 1,
+        title: title ?? listing.title,
+        description: description ?? listing.description,
+        price: price !== undefined ? Number(price) : listing.price,
+      },
+    });
+    await prisma.listing.update({
+      where: { id: listingId },
+      data: {
+        title: newVersion.title,
+        description: newVersion.description,
+        price: newVersion.price,
+        updatedAt: new Date(),
+      },
+    });
+    return res.json({ success: true, data: newVersion });
+  } catch (error) {
+    return res.status(500).json({ success: false, error: (error as Error).message });
+  }
+}

--- a/src/pages/api/listings/[id]/renew.ts
+++ b/src/pages/api/listings/[id]/renew.ts
@@ -1,0 +1,27 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../../auth/[...nextauth]";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).end();
+  const session = await getServerSession(req, res, authOptions as any);
+  if (!session?.user?.id) return res.status(401).json({ success: false, error: "Unauthorized" });
+  const listingId = req.query.id as string;
+  try {
+    const listing = await prisma.listing.findUnique({ where: { id: listingId } });
+    if (!listing || listing.userId !== session.user.id) {
+      return res.status(403).json({ success: false, error: "Forbidden" });
+    }
+    const expiresAt = new Date(Date.now() + 60 * 24 * 60 * 60 * 1000);
+    await prisma.listing.update({
+      where: { id: listingId },
+      data: { expiresAt, status: "ACTIVE" },
+    });
+    return res.json({ success: true, data: { expiresAt } });
+  } catch (error) {
+    return res.status(500).json({ success: false, error: (error as Error).message });
+  }
+}

--- a/src/pages/api/listings/create.ts
+++ b/src/pages/api/listings/create.ts
@@ -1,0 +1,40 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../auth/[...nextauth]";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).end();
+  const session = await getServerSession(req, res, authOptions as any);
+  if (!session?.user?.id) return res.status(401).json({ success: false, error: "Unauthorized" });
+  const { title, description, categoryId, price } = req.body;
+  if (!title || !description || !categoryId) {
+    return res.status(400).json({ success: false, error: "Missing fields" });
+  }
+  try {
+    const listing = await prisma.listing.create({
+      data: {
+        userId: session.user.id,
+        categoryId,
+        title,
+        description,
+        price: price ? Number(price) : null,
+        expiresAt: new Date(Date.now() + 60 * 24 * 60 * 60 * 1000),
+        versions: {
+          create: {
+            version: 1,
+            title,
+            description,
+            price: price ? Number(price) : null,
+          },
+        },
+      },
+      include: { versions: true },
+    });
+    return res.json({ success: true, data: listing });
+  } catch (error) {
+    return res.status(500).json({ success: false, error: (error as Error).message });
+  }
+}

--- a/src/pages/api/payments/createPaidListing.ts
+++ b/src/pages/api/payments/createPaidListing.ts
@@ -1,0 +1,37 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../auth/[...nextauth]";
+import Stripe from "stripe";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: "2022-11-15" });
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).end();
+  const session = await getServerSession(req, res, authOptions as any);
+  if (!session?.user?.id) return res.status(401).json({ success: false, error: "Unauthorized" });
+  const { listingId, amount } = req.body;
+  try {
+    const listing = await prisma.listing.findUnique({ where: { id: listingId } });
+    if (!listing || listing.userId !== session.user.id) {
+      return res.status(403).json({ success: false, error: "Forbidden" });
+    }
+    const paymentLink = await stripe.paymentLinks.create({
+      line_items: [{ price_data: { currency: "cad", product_data: { name: listing.title }, unit_amount: Math.round(Number(amount) * 100) }, quantity: 1 }],
+      metadata: { listingId, userId: session.user.id },
+    });
+    await prisma.payment.create({
+      data: {
+        userId: session.user.id,
+        listingId,
+        stripeId: paymentLink.id,
+        amount: Number(amount),
+        currency: "CAD",
+      },
+    });
+    return res.json({ success: true, data: { url: paymentLink.url } });
+  } catch (error) {
+    return res.status(500).json({ success: false, error: (error as Error).message });
+  }
+}

--- a/src/pages/api/payments/webhook.ts
+++ b/src/pages/api/payments/webhook.ts
@@ -1,0 +1,38 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import Stripe from "stripe";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: "2022-11-15" });
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const sig = req.headers["stripe-signature"] as string;
+  const buf = await new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", chunk => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", err => reject(err));
+  });
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(buf, sig, process.env.STRIPE_WEBHOOK_SECRET!);
+  } catch (err) {
+    return res.status(400).send(`Webhook Error: ${(err as Error).message}`);
+  }
+  if (event.type === "payment_link.updated") {
+    const link = event.data.object as Stripe.PaymentLink;
+    if (link.active === false) {
+      const metadata = link.metadata || {};
+      const listingId = metadata.listingId;
+      await prisma.listing.update({ where: { id: listingId }, data: { promoted: true } });
+      await prisma.payment.updateMany({ where: { stripeId: link.id }, data: { status: "SUCCESS" } });
+    }
+  }
+  res.json({ received: true });
+}

--- a/src/pages/api/user/[id]/trust.ts
+++ b/src/pages/api/user/[id]/trust.ts
@@ -1,0 +1,13 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { getTrustScore } from "../../../lib/trust";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") return res.status(405).end();
+  const userId = req.query.id as string;
+  try {
+    const score = await getTrustScore(userId);
+    return res.json({ success: true, data: { score } });
+  } catch (error) {
+    return res.status(500).json({ success: false, error: (error as Error).message });
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,30 @@
+import useSWR from "swr";
+import Link from "next/link";
+
+type Listing = {
+  id: string;
+  title: string;
+  promoted: boolean;
+  user: { id: string };
+  trustScore: number;
+};
+
+async function fetcher(url: string) {
+  const res = await fetch(url);
+  return res.json();
+}
+
+export default function FeedPage() {
+  const { data } = useSWR<{ success: boolean; data: Listing[] }>("/api/feed", fetcher);
+  return (
+    <div className="p-4 grid gap-4">
+      {data?.data.map(listing => (
+        <div key={listing.id} className="border p-2 rounded">
+          <Link href={`/listing/${listing.id}`}>{listing.title}</Link>
+          {listing.promoted && <span className="ml-2 text-sm text-yellow-500">PROMOTED</span>}
+          <span className="ml-4 text-sm">Trust: {listing.trustScore.toFixed(1)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/support.tsx
+++ b/src/pages/support.tsx
@@ -1,0 +1,32 @@
+import { useState } from "react";
+
+export default function SupportPage() {
+  const [messages, setMessages] = useState<{ role: string; content: string }[]>([]);
+  const [input, setInput] = useState("");
+
+  const sendMessage = async () => {
+    setMessages([...messages, { role: "user", content: input }]);
+    setInput("");
+    // TODO: call OpenAI chat completion API
+  };
+
+  return (
+    <div className="p-4">
+      <div className="border p-2 h-64 overflow-y-scroll">
+        {messages.map((m, i) => (
+          <div key={i}>{m.role}: {m.content}</div>
+        ))}
+      </div>
+      <input
+        value={input}
+        onChange={e => setInput(e.target.value)}
+        className="border p-2 w-full"
+        placeholder="Ask us anything"
+      />
+      <button onClick={sendMessage} className="mt-2 bg-blue-500 text-white px-4 py-2 rounded">
+        Send
+      </button>
+      <p className="mt-4">日本語サポート: <a href="mailto:jp-support@example.com" className="underline">メールする</a></p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Prisma schema for classifieds app
- implement NextAuth configuration
- add listing CRUD/renew endpoints
- add payments flow and webhook
- add trust score helper and feed API
- include support and feed pages
- add cron job for expiring listings

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_684262ae6fa08324abab349b9a719070